### PR TITLE
Cursor errors

### DIFF
--- a/lib/swiss_db/cursor.rb
+++ b/lib/swiss_db/cursor.rb
@@ -67,23 +67,29 @@ class Cursor # < Array
   def method_missing(methId, *args)
     str = methId.id2name
     if args.count == 0
-      index = cursor.getColumnIndex(str)
-      type = cursor.getType(index)
-      # puts "getting field #{str} at index #{index} of type #{type}"
-      if type == FIELD_TYPE_STRING
-        cursor.getString(index)
-      elsif type == FIELD_TYPE_INTEGER
-        cursor.getInt(index)
-      elsif type == FIELD_TYPE_NULL
-        nil #??
-      elsif type == FIELD_TYPE_FLOAT
-        cursor.getFloat(index)
-      elsif type == FIELD_TYPE_BLOB
-        cursor.getBlob(index)
-      end
-    elsif args.count == 1
+      get_index
+    elsif args.count == 1 && str[-1] == '='
       # assignment... add to values to save
       @values[str.gsub!("=", "")] = args[0]
+    else
+      super
+    end
+  end
+
+  def get_index
+    index = cursor.getColumnIndex(str)
+    type = cursor.getType(index)
+    # puts "getting field #{str} at index #{index} of type #{type}"
+    if type == FIELD_TYPE_STRING
+      cursor.getString(index)
+    elsif type == FIELD_TYPE_INTEGER
+      cursor.getInt(index)
+    elsif type == FIELD_TYPE_NULL
+      nil #??
+    elsif type == FIELD_TYPE_FLOAT
+      cursor.getFloat(index)
+    elsif type == FIELD_TYPE_BLOB
+      cursor.getBlob(index)
     end
   end
 


### PR DESCRIPTION
One problem I ran into last weekend was that I called `map` on a cursor object and I got a hard to decode error. Something like `undefined method Integer on <#<#0x3839 Object >`

Took me a while to figure out!

So I updated the way cursor uses `method_missing` to hopefully be a little more robust and throw better errors. Now it says `undefined method map for a Cursor`.

Oops, and looking at the diff now it looks like my 'table_names' thing got into this branch. Do you want me to leave it or get rid of it to focus the PR a little better?
