### PR TITLE
Some improvements 

### DIFF
--- a/lib/swiss_db/cursor.rb
+++ b/lib/swiss_db/cursor.rb
@@ -109,6 +109,12 @@ module SwissDB
 
       if type == FIELD_TYPE_STRING #also boolean
         str = cursor.getString(index).to_s
+
+        if str =~ /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}/
+          formatter = Java::Text::SimpleDateFormat.new('yyyy-MM-dd hh:mm:ss.SSS')
+          str = formatter.parse(str)
+        end
+
         str = true if str == "true"
         str = false if str == "false"
         str

--- a/lib/swiss_db/cursor.rb
+++ b/lib/swiss_db/cursor.rb
@@ -130,6 +130,33 @@ module SwissDB
     def column_names
       cursor.getColumnNames.map(&:to_sym)
     end
+
+    def map(&block)
+      return [] if count == 0
+      arr = []
+      (0...count).each do |i|
+        # puts i
+        cursor.moveToPosition(i)
+        arr << yield(model.new(to_hash))
+      end
+
+      arr
+    end
+
+    def each(&block)
+      return [] if count == 0
+      arr = []
+      (0...count).each do |i|
+        # puts i
+        cursor.moveToPosition(i)
+        m = model.new(to_hash)
+        yield(m)
+        arr << m
+      end
+
+      arr
+    end
+
     # those methods allow the use of PMCursorAdapter with SwissDB
     def moveToPosition(i)
       cursor.moveToPosition(i)

--- a/lib/swiss_db/cursor.rb
+++ b/lib/swiss_db/cursor.rb
@@ -126,5 +126,17 @@ module SwissDB
     def column_names
       cursor.getColumnNames.map(&:to_sym)
     end
+    # those methods allow the use of PMCursorAdapter with SwissDB
+    def moveToPosition(i)
+      cursor.moveToPosition(i)
+    end
+
+    def moveToLast
+      cursor.moveToLast
+    end
+
+    def moveToFirst
+      cursor.moveToFirst
+    end
   end
 end

--- a/lib/swiss_db/cursor.rb
+++ b/lib/swiss_db/cursor.rb
@@ -45,6 +45,10 @@ module SwissDB
       swiss_model
     end
 
+    def current
+      model.new(to_hash)
+    end
+
     def [](pos)
       begin
         return nil if count == 0

--- a/lib/swiss_db/data_store.rb
+++ b/lib/swiss_db/data_store.rb
@@ -31,7 +31,7 @@ module SwissDB
       # puts "inserting data in #{table}"
       values = ContentValues.new(hash_values.count)
       hash_values.each do |k, v|
-        values.put(k, v)
+        values.put(k, coerces(v))
       end
       result = db.insert(table, nil, values)
       result
@@ -47,7 +47,7 @@ module SwissDB
     def select(db=writable_db, table, values, model)
       puts "selecting data from #{table}"
       value_str = values.map do |k, v|
-        "#{k} = '#{v}'"
+        "#{k} = '#{coerces(v)}'"
       end.join(" AND ")
       sql = "select * from '#{table}' where #{value_str}"
       puts sql
@@ -59,10 +59,10 @@ module SwissDB
 
     def update(db=writable_db, table, values, where_values)
       value_str = values.map do |k, v|
-        "'#{k}' = '#{v}'"
+        "'#{k}' = '#{coerces(v)}'"
       end.join(",")
       where_str = where_values.map do |k, v|
-        "#{k} = '#{v}'"
+        "#{k} = '#{coerces(v)}'"
       end.join(",")
       sql = "update '#{table}' set #{value_str} where #{where_str}"
       puts sql
@@ -74,6 +74,16 @@ module SwissDB
     def destroy_all(db=writable_db, table) # WARNING!
       puts "destroying all from #{table}"
       db.delete(table, nil, nil)
+    end
+
+    # transform values
+    def coerces(v)
+      if v.is_a?(Time)
+        formatter = Java::Text::SimpleDateFormat.new('yyyy-MM-dd hh:mm:ss.SSS')
+        formatter.format(v).to_s
+      else
+        v.to_s
+      end
     end
   end
 end

--- a/lib/swiss_db/swiss_model.rb
+++ b/lib/swiss_db/swiss_model.rb
@@ -49,6 +49,8 @@ module SwissDB
         store.insert(table_name,
                      @values)
       end
+
+      @values = {}
     end
 
     def update_attribute(key, value)


### PR DESCRIPTION
This PR
- add some methods to allow the use of SwissDB with BluePotion PMCursorAdapter (expose `moveToPosition()`, `moveToLast` and `moveToFirst`)
- add `cursor.current` to retrieve the model a current position (usefull with PMCursorAdapter which send you the cursor ie)
- allow saving and restoring `Time` 

```
t = SomeModel.create({ date: Time.new })
t.date > Time.new
=> false
```
- clean `@values` on `SwissModel.save` to avoid this

``` sh
>> m = (some_model)
>> m.name = 'foo'
>> m.save
update 'some_models' set 'name' = 'foo' where id = '1'
>> m.sub_name ='bar'
>> m.save
update 'some_models' set 'name' = 'foo','sub_name' = 'bar' where id = '1'
```

But instead, the second will be

``` sh
update 'some_models' set 'sub_name' = 'bar' where id = '1'
```
- add `each` and `map` to `Cursor` to allow `Model.all.each|map` without passing by a `to_a`
